### PR TITLE
tilde expansion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ SRCS	=	\
 			parser/build/parser_build_list_unstack_lexer_glob_brace.c	\
 			parser/expand/expand.c										\
 			parser/expand/expand_glob_brace.c							\
+			parser/expand/expand_tilde.c								\
 			parser/lexer/lexer_bufferize.c								\
 			parser/lexer/lexer_token_add.c								\
 			parser/lexer/lexer_tokens_alloc.c							\

--- a/incs/parser.h
+++ b/incs/parser.h
@@ -55,6 +55,7 @@ int		parser_build_list_unstack_lexer_glob_brace(t_parser *parser,
 
 int		expand(t_lexer *lexer, t_proc *p, int *i);
 int		expand_glob_brace(t_sh *sh, t_list **argv_list);
+int		expand_tilde(t_sh *sh, t_list **argv_list);
 
 /*
 ** Function pointers for the parser.

--- a/incs/parser_struct.h
+++ b/incs/parser_struct.h
@@ -64,7 +64,6 @@ typedef enum			e_token_code
 	TC_SPACE,
 	TC_TAB,
 	TC_NEWLINE,
-	TC_TILDE,
 	TC_LPAREN,
 	TC_RPAREN,
 	TC_RANGE,

--- a/incs/parser_tokens.h
+++ b/incs/parser_tokens.h
@@ -275,16 +275,6 @@ static t_token g_token_globing_inhibitor_quote = {
 	0
 };
 
-static t_token g_token_globing_name_tilde = {
-	"~",
-	NULL,
-	1,
-	TT_NAME,
-	TC_TILDE,
-	token_globing_parse_none,
-	0
-};
-
 
 /*
 ** Tokens for glob brace expansion `{}`

--- a/srcs/parser/alloc/parser_new.c
+++ b/srcs/parser/alloc/parser_new.c
@@ -25,7 +25,6 @@ static int	s_build_token_globing(t_parser *parser)
 	i = 0;
 	parser->token_list[i++] = &g_token_globing_inhibitor_dquote;
 	parser->token_list[i++] = &g_token_globing_inhibitor_quote;
-	parser->token_list[i++] = &g_token_globing_name_tilde;
 	parser->token_list[i++] = NULL;
 	return (ST_OK);
 }

--- a/srcs/parser/expand/expand.c
+++ b/srcs/parser/expand/expand.c
@@ -84,6 +84,8 @@ int			expand(t_lexer *lexer, t_proc *p, int *i)
 	{
 		// NOTE:
 		// F_PARSING_GLOBING probably should work with the same behavior
+		if ((ret = expand_tilde(lexer->sh, &argv_list)) != ST_OK)
+			return (ret);
 		if ((ret = expand_glob_brace(lexer->sh, &argv_list)) != ST_OK)
 			return (ret);
 	}

--- a/srcs/parser/expand/expand_glob_brace.c
+++ b/srcs/parser/expand/expand_glob_brace.c
@@ -10,6 +10,7 @@ int			expand_glob_brace(t_sh *sh, t_list **argv_list)
 
 	if ((new_argv_list = (t_list *)malloc(sizeof(t_list))) == NULL)
 		return (ST_MALLOC);
+	ret = ST_OK;
 	INIT_LIST_HEAD(new_argv_list);
 	safe = (*argv_list)->next;
 	while ((pos = safe) && safe != *argv_list)

--- a/srcs/parser/expand/expand_tilde.c
+++ b/srcs/parser/expand/expand_tilde.c
@@ -1,0 +1,65 @@
+#include "shell.h"
+
+static int	s_replace_tilde_with(t_argv *argument, char *str, int offset)
+{
+	char	*new_buffer;
+	size_t	len;
+
+	if (!str)
+		return (ST_OK);
+	len = ft_strlen(str);
+	if ((new_buffer = (char *)malloc(sizeof(char) * (len
+		+ ft_strlen(argument->buffer)))) == NULL)
+		return (ST_MALLOC);
+	ft_strcat(new_buffer, str);
+	ft_strcat(new_buffer + len, argument->buffer + offset);
+	free(argument->buffer);
+	argument->buffer = new_buffer;
+	return (ST_OK);
+}
+
+static int	s_process_pwd(t_sh *sh, t_argv *argument, t_argv *argument_next)
+{
+	if (argument->buffer[2] == '\0')
+	{
+		if (argument_next && argument_next->buffer
+			&& argument_next->buffer[0] != '\0'
+			&& argument_next->buffer[0] != '/')
+			return (ST_OK);
+	}
+	else if (argument->buffer[2] != '/')
+		return (ST_OK);
+	if (argument->buffer[1] == '+')
+		return (s_replace_tilde_with(argument, env_get(sh->envp, "PWD"), 2));
+	return (s_replace_tilde_with(argument, env_get(sh->envp, "OLDPWD"), 2));
+}
+
+static int	s_process_user(t_sh *sh, t_argv *argument, t_argv *argument_next)
+{
+	(void)sh;
+	(void)argument;
+	(void)argument_next;
+	return (ST_OK);
+}
+
+int			expand_tilde(t_sh *sh, t_list **argv_list)
+{
+	t_list	*pos;
+	t_argv	*argument;
+	t_argv	*argument_next;
+
+	pos = (*argv_list)->next;
+	if (pos == *argv_list)
+		return (ST_OK);
+	argument = CONTAINER_OF(pos, t_argv, argv_list);
+	argument_next = NULL;
+	if (pos->next != *argv_list)
+		argument_next = CONTAINER_OF(pos->next, t_argv, argv_list);
+	if (!(argument->buffer && argument->buffer[0] == '~'))
+		return (ST_OK);
+	if (argument->buffer[1] == '/')
+		return (s_replace_tilde_with(argument, env_get_home(sh->envp), 1));
+	if (argument->buffer[1] == '+' || argument->buffer[1] == '-')
+		return (s_process_pwd(sh, argument, argument_next));
+	return (s_process_user(sh, argument, argument_next));
+}

--- a/srcs/parser/expand/expand_tilde.c
+++ b/srcs/parser/expand/expand_tilde.c
@@ -5,16 +5,17 @@ static int	s_replace_tilde_with(t_argv *argument, char *str, int offset)
 	char	*new_buffer;
 	size_t	len;
 
-	if (!str)
+	log_debug("1");
+	if (str == NULL)
 		return (ST_OK);
 	len = ft_strlen(str);
-	if ((new_buffer = (char *)malloc(sizeof(char) * (len
-		+ ft_strlen(argument->buffer)))) == NULL)
+	if ((new_buffer = ft_strnew(len + ft_strlen(argument->buffer))) == NULL)
 		return (ST_MALLOC);
 	ft_strcat(new_buffer, str);
 	ft_strcat(new_buffer + len, argument->buffer + offset);
 	free(argument->buffer);
 	argument->buffer = new_buffer;
+	log_debug("2");
 	return (ST_OK);
 }
 
@@ -34,11 +35,23 @@ static int	s_process_pwd(t_sh *sh, t_argv *argument, t_argv *argument_next)
 	return (s_replace_tilde_with(argument, env_get(sh->envp, "OLDPWD"), 2));
 }
 
-static int	s_process_user(t_sh *sh, t_argv *argument, t_argv *argument_next)
+static int	s_process_user(t_argv *argument)
 {
-	(void)sh;
-	(void)argument;
-	(void)argument_next;
+	char			*user;
+	struct passwd	*passwd;
+	size_t			len;
+
+	len = 0;
+	user = argument->buffer + 1;
+	while(user[len] != '\0' && user[len] != '/')
+		len++;
+	if ((user = ft_strnew(len)) == NULL)
+		return (ST_MALLOC);
+	ft_strncat(user, argument->buffer + 1, len);
+	passwd = getpwnam(user);
+	free(user);
+	if (passwd != NULL)
+		return (s_replace_tilde_with(argument, passwd->pw_dir, 1 + len));
 	return (ST_OK);
 }
 
@@ -53,13 +66,17 @@ int			expand_tilde(t_sh *sh, t_list **argv_list)
 		return (ST_OK);
 	argument = CONTAINER_OF(pos, t_argv, argv_list);
 	argument_next = NULL;
+	log_debug("--> %s", argument->buffer);
 	if (pos->next != *argv_list)
 		argument_next = CONTAINER_OF(pos->next, t_argv, argv_list);
-	if (!(argument->buffer && argument->buffer[0] == '~'))
+	if (!(argument->buffer != NULL && argument->buffer[0] == '~'))
 		return (ST_OK);
-	if (argument->buffer[1] == '/')
+	if (argument->buffer[1] == '/' || (argument->buffer[1] == '\0'
+		&& (argument_next == NULL || (argument_next->buffer
+		&& (argument_next->buffer[0] == '\0'
+		|| argument_next->buffer[0] == '/')))))
 		return (s_replace_tilde_with(argument, env_get_home(sh->envp), 1));
 	if (argument->buffer[1] == '+' || argument->buffer[1] == '-')
 		return (s_process_pwd(sh, argument, argument_next));
-	return (s_process_user(sh, argument, argument_next));
+	return (s_process_user(argument));
 }

--- a/srcs/parser/expand/expand_tilde.c
+++ b/srcs/parser/expand/expand_tilde.c
@@ -5,7 +5,6 @@ static int	s_replace_tilde_with(t_argv *argument, char *str, int offset)
 	char	*new_buffer;
 	size_t	len;
 
-	log_debug("1");
 	if (str == NULL)
 		return (ST_OK);
 	len = ft_strlen(str);
@@ -15,7 +14,6 @@ static int	s_replace_tilde_with(t_argv *argument, char *str, int offset)
 	ft_strcat(new_buffer + len, argument->buffer + offset);
 	free(argument->buffer);
 	argument->buffer = new_buffer;
-	log_debug("2");
 	return (ST_OK);
 }
 
@@ -66,7 +64,6 @@ int			expand_tilde(t_sh *sh, t_list **argv_list)
 		return (ST_OK);
 	argument = CONTAINER_OF(pos, t_argv, argv_list);
 	argument_next = NULL;
-	log_debug("--> %s", argument->buffer);
 	if (pos->next != *argv_list)
 		argument_next = CONTAINER_OF(pos->next, t_argv, argv_list);
 	if (!(argument->buffer != NULL && argument->buffer[0] == '~'))

--- a/srcs/parser/token/token_globing_parse_none.c
+++ b/srcs/parser/token/token_globing_parse_none.c
@@ -1,28 +1,5 @@
 #include "shell.h"
 
-static int	s_replace_tilde(t_parser *parser, void *target, char *output)
-{
-	t_argv	*argument;
-	char	*tmp;
-	char	*tmp2;
-	int		ret;
-
-	ret = ST_OK;
-	argument = (t_argv *)target;
-	tmp = env_get_home(parser->sh->envp);
-	if (tmp)
-	{
-		tmp2 = argument->buffer;
-		if ((argument->buffer = ft_strjoin(tmp, output + 1)) == NULL)
-			return (ST_MALLOC);
-		free(tmp2);
-	}
-	else
-		ret = token_globing_parse_utils_push_str(parser->target_list_head,
-					output);
-	return (ret);
-}
-
 int			token_globing_parse_none(void *target, t_parser *parser,
 				t_lexer *lexer, int *i)
 {
@@ -37,14 +14,7 @@ int			token_globing_parse_none(void *target, t_parser *parser,
 	if (output[0] != '\0')
 	{
 		((t_argv *)target)->is_null = 0;
-		if (*i == 0 &&
-			(output[0] == '~' && (output[1] == '\0' || output[1] == '/')))
-		{
-			if ((s_replace_tilde(parser, target, output)) == ST_MALLOC)
-				return (ST_MALLOC);
-		}
-		else
-			ret = token_globing_parse_utils_push_str(parser->target_list_head,
+		ret = token_globing_parse_utils_push_str(parser->target_list_head,
 						output);
 	}
 	(*i)++;


### PR DESCRIPTION
DONE:
```bash
echo ~
echo ~/abc
echo ~+
echo ~+abc # does nothing
echo ~+/abc
echo ~-
echo ~-abc # does nothing
echo ~-/abc
echo ~INVALID_USER # does nothing
echo ~INVALID_USER/ # does nothing
echo ~VALID_USER
echo ~VALID_USER/
```

BONUS (that `bash` does not support):
```bash
# using simple or double quotes:
echo ~""
echo ~"/abc"
echo ~+""
echo ~+"abc" # does nothing
echo ~+"/abc"
echo ~-""
echo ~-"abc" # does nothing
echo ~-"/abc"
```